### PR TITLE
Report unsupported GCP machine types as a user error

### DIFF
--- a/src/elastic_blast/elb_config.py
+++ b/src/elastic_blast/elb_config.py
@@ -1214,7 +1214,7 @@ def get_instance_props(cloud_provider: CSP, region: str, machine_type: str) -> I
             instance_props = gcp_get_machine_properties(machine_type)
         else:
             instance_props = aws_get_machine_properties(machine_type, create_aws_config(region))
-    except NotImplementedError as err:
+    except (NotImplementedError, KeyError) as err:
         raise UserReportError(returncode=INPUT_ERROR,
                               message=f'Invalid machine type. Machine type name "{machine_type}" is incorrect or not supported by ElasticBLAST: {str(err)}')
     return instance_props

--- a/src/elastic_blast/tuner.py
+++ b/src/elastic_blast/tuner.py
@@ -281,7 +281,7 @@ def gcp_get_mem_limit(machine_type: str) -> float:
         A search job memory limit int GB as float"""
     try:
         props = gcp_get_machine_properties(machine_type)
-    except NotImplementedError as err:
+    except (NotImplementedError, KeyError) as err:
         raise UserReportError(returncode=INPUT_ERROR,
                               message=f'Invalid machine type. Machine type name "{machine_type}" is incorrect or not supported by ElasticBLAST: {str(err)}')
 

--- a/tests/tuner/test_tuner.py
+++ b/tests/tuner/test_tuner.py
@@ -221,6 +221,16 @@ def test_gcp_get_mem_limit():
     assert gcp_get_mem_limit(MACHINE_TYPE) == props.memory - SYSTEM_MEMORY_RESERVE
 
 
+def test_gcp_get_mem_limit_unsupported_machine_type():
+    """A well formed GCP machine type from a series we do not list must be
+    reported as a user error, not raise KeyError"""
+    for machine_type in ['c2d-standard-4', 't2d-standard-8', 'n4-standard-16']:
+        with pytest.raises(UserReportError) as err:
+            gcp_get_mem_limit(machine_type)
+        assert err.value.returncode == INPUT_ERROR
+        assert 'Invalid machine type' in err.value.message
+
+
 @patch(target='elastic_blast.tuner.aws_get_machine_properties', new=MagicMock(return_value=InstanceProperties(32, 128)))
 @patch(target=__name__ + '.aws_get_machine_properties', new=MagicMock(return_value=InstanceProperties(32, 128)))
 def test_get_mem_limit():


### PR DESCRIPTION
Requesting a real GCP machine type that ElasticBLAST has not catalogued gives an uncaught `KeyError` traceback rather than the friendly message the code clearly intends:

```
>>> tuner.gcp_get_mem_limit("c2d-standard-4")
KeyError: 'c2d-standard'
```

`gcp_traits.get_machine_properties` matches the type against `([^-]+-[^-]+)-([0-9]+)` and then indexes `GCP_MACHINES[series]`. A well formed type from a series that is not in that dict (c2d, t2d, n4, c3, and the other newer families) matches the regex, so it never reaches the `else` branch that raises `NotImplementedError`; it dies on the dict lookup instead. Both user-facing callers, `tuner.gcp_get_mem_limit` and `elb_config.get_instance_props`, catch only `NotImplementedError`, so the `KeyError` escapes to the user during config validation.

I left the low-level function alone on purpose. `tests/gcp_traits/test_gcp_traits.py::test_not_found` asserts that `get_machine_properties("n1-nonstandard-32")` raises `KeyError`, so that behavior is part of the tested contract. Widening the two callers to `except (NotImplementedError, KeyError)` is the smaller change and keeps that test passing.

Added a test that asserts `c2d-standard-4`, `t2d-standard-8` and `n4-standard-16` raise `UserReportError` with `INPUT_ERROR`. It fails before the change with `KeyError: 'c2d-standard'` and passes after. `tests/tuner tests/gcp_traits tests/base tests/elb_config` run 74 passed with the fix in place.